### PR TITLE
Two way get supply

### DIFF
--- a/examples/bigger-example-3.rcp
+++ b/examples/bigger-example-3.rcp
@@ -16,7 +16,7 @@ agent Client
     receive-guard: (chan == *) | (chan == cLink)
 
     repeat: (
-            {true} GET@(b) []
+            {true} GET@(b)() []
             +
             {true} SUPPLY@(any)() []
             +

--- a/examples/broadcast.rcp
+++ b/examples/broadcast.rcp
@@ -1,0 +1,28 @@
+message-structure: A: bool, B: bool
+
+agent Sender 
+    receive-guard: true
+    init: true
+    repeat: (
+        snd : {true} *! (true) (A := false) []
+    )
+
+agent Re1
+    local: x: bool
+    init: x
+    receive-guard: true
+    repeat: (
+        recv1 : {true} *? [x := A]
+    )
+
+agent Re2
+    local: x: bool, y: bool
+    init: x & y
+    receive-guard: true
+    repeat: (
+        recv2 : {true} *? [x := A, y := B]
+    )
+
+system = Sender(s, true) || Re1(r1, true) || Re2(r2, true)
+
+SPEC X false;

--- a/examples/twoway.rcp
+++ b/examples/twoway.rcp
@@ -1,0 +1,20 @@
+message-structure: NAME : location
+
+agent Node
+    local: loc1 : location, loc2 : location, stage: 0..1
+    init: loc1 = myself & loc2 = myself & stage = 0
+    receive-guard: (chan == *)
+
+    repeat: (
+        splyName: {true} SUPPLY@(myself) (NAME := myself) [loc2 := NAME]
+        +
+        getName: {true} GET@(loc1) (NAME := myself) [loc2 := NAME]
+        +
+        bcast1: {stage = 0} *! (true) (NAME := loc1) [stage := 1]
+        +
+        bcast2: {stage = 0} *? [loc1 := NAME, stage := 1]
+    )
+
+system = Node(one, true) || Node(two, true)
+
+SPEC X X false;

--- a/src/language/r-check.langium
+++ b/src/language/r-check.langium
@@ -58,7 +58,7 @@ Send:
 Receive: 
     CmdHeader chanExpr=ChannelExpr '?' Update;
 Get: 
-    CmdHeader op='GET@' '(' where=LocationExpr ')' Update ;
+    CmdHeader op='GET@' '(' where=LocationExpr ')' Data Update ;
 Supply: 
     CmdHeader op='SUPPLY@' '(' where=SupplyLocationExpr ')' Data Update ;
 


### PR DESCRIPTION
This adds initial support for two-way point-to-point communication to R-CHECK.

Intuitively, a supply process can now have message variables in its updates:

```
SUPPLY@myself (MSG := someValue) [var := VAR] 
```

And a get process can now have a data part:

```
GET@x (VAR := value) [localVar := MSG]
```

When two agents with commands of this kind synchronize, data from each agent will be sent to the other and bound to its local variables according to the update expressions.

Caveats: 

* The synchronization can only take place if both parties obtain all the data they require in their respective updates.
* At the moment we do not allow the supplier to guard on the value of data.
* The getter is still considered to be the initiator of the interaction.
* The two agents can use the same variables! It will be implicit that occurrences in the update part always resolve to the value received from the other party.

See `examples/twoway.rcp` for an example.