### PR TITLE
Support GET@predicate, locations in instance init

### DIFF
--- a/examples/bigger-example-3.rcp
+++ b/examples/bigger-example-3.rcp
@@ -16,7 +16,7 @@ agent Client
     receive-guard: (chan == *) | (chan == cLink)
 
     repeat: (
-            {true} GET@(b) []
+            {true} GET@(b)() []
             +
             {true} SUPPLY@(any)() []
             +

--- a/examples/broadcast.rcp
+++ b/examples/broadcast.rcp
@@ -1,0 +1,28 @@
+message-structure: A: bool, B: bool
+
+agent Sender 
+    receive-guard: true
+    init: true
+    repeat: (
+        snd : {true} *! (true) (A := false) []
+    )
+
+agent Re1
+    local: x: bool
+    init: x
+    receive-guard: true
+    repeat: (
+        recv1 : {true} *? [x := A]
+    )
+
+agent Re2
+    local: x: bool, y: bool
+    init: x & y
+    receive-guard: true
+    repeat: (
+        recv2 : {true} *? [x := A, y := B]
+    )
+
+system = Sender(s, true) || Re1(r1, true) || Re2(r2, true)
+
+SPEC X false;

--- a/examples/twoway.rcp
+++ b/examples/twoway.rcp
@@ -1,0 +1,20 @@
+message-structure: NAME : location
+
+agent Node
+    local: loc1 : location, loc2 : location, stage: 0..1
+    init: loc1 = myself & loc2 = myself & stage = 0
+    receive-guard: (chan == *)
+
+    repeat: (
+        splyName: {true} SUPPLY@(myself) (NAME := myself) [loc2 := NAME]
+        +
+        getName: {true} GET@(loc1) (NAME := myself) [loc2 := NAME]
+        +
+        bcast1: {stage = 0} *! (true) (NAME := loc1) [stage := 1]
+        +
+        bcast2: {stage = 0} *? [loc1 := NAME, stage := 1]
+    )
+
+system = Node(one, true) || Node(two, true)
+
+SPEC X X false;

--- a/examples/twoway.rcp
+++ b/examples/twoway.rcp
@@ -2,19 +2,15 @@ message-structure: NAME : location
 
 agent Node
     local: loc1 : location, loc2 : location, stage: 0..1
-    init: loc1 = myself & loc2 = myself & stage = 0
+    init: loc2 = myself & stage = 0
     receive-guard: (chan == *)
 
     repeat: (
-        splyName: {true} SUPPLY@(myself) (NAME := myself) [loc2 := NAME]
+        splyName: {true} SUPPLY@(any) (NAME := myself) [loc2 := NAME]
         +
-        getName: {true} GET@(loc1) (NAME := myself) [loc2 := NAME]
-        +
-        bcast1: {stage = 0} *! (true) (NAME := loc1) [stage := 1]
-        +
-        bcast2: {stage = 0} *? [loc1 := NAME, stage := 1]
+        getName: {true} GET@(true) (NAME := myself) [loc2 := NAME]
     )
 
-system = Node(one, true) || Node(two, true)
+system = Node(one, loc1=two) || Node(two, loc1=one)
 
-SPEC X X false;
+SPEC G (one-loc2 != two);

--- a/src/language/r-check.langium
+++ b/src/language/r-check.langium
@@ -58,7 +58,7 @@ Send:
 Receive: 
     CmdHeader chanExpr=ChannelExpr '?' Update;
 Get: 
-    CmdHeader op='GET@' '(' where=LocationExpr ')' Update ;
+    CmdHeader op='GET@' '(' where=LocationExpr ')' Data Update ;
 Supply: 
     CmdHeader op='SUPPLY@' '(' where=SupplyLocationExpr ')' Data Update ;
 

--- a/src/language/r-check.langium
+++ b/src/language/r-check.langium
@@ -58,7 +58,7 @@ Send:
 Receive: 
     CmdHeader chanExpr=ChannelExpr '?' Update;
 Get: 
-    CmdHeader op='GET@' '(' where=LocationExpr ')' Data Update ;
+    CmdHeader op='GET@' '(' where=GetLocationExpr ')' Data Update ;
 Supply: 
     CmdHeader op='SUPPLY@' '(' where=SupplyLocationExpr ')' Data Update ;
 
@@ -72,9 +72,8 @@ ChannelExpr: (channel=[ChannelExprRef] | bcast = '*');
 LocationExprRef: Instance | Local;
 LocationExpr: (location=[LocationExprRef]);
 SupplyLocationExpr: (location=[LocationExprRef] | myself="myself" | any="any");
+GetLocationExpr: (location=[LocationExprRef] | predicate=CompoundExpr);
 
-//fragment TypedDeclaration: 
-//    name=ID ':' (builtinType=('bool'|'int'|'channel'|'location') | customType=[Enum] | rangeType=Range);
 
 fragment TypedDeclaration: 
     name=ID ':' (builtinType=('bool'|'int'|'location') | customType=[Enum] | rangeType=Range);


### PR DESCRIPTION
This PR enables support for GET@predicate.

A quick recap: This allows to get data from a supplier that satisfies a given predicate, without knowing its exact name (assuming that the supplier is performing `SUPPLY@any` rather than `SUPPLY@myself`, which requires explicit knowledge of its name).

This was supported in the Java tool, so this PR simply adds support for the construct in the grammar. However, we also update the Java code so that:

* It can correctly deserialize GET@predicate AST nodes
* It allows location names to be used in the init expression of agent instances. For instance, if an `agent A` has a local variable `loc: location`, it is now possible to write systems like the following:

```
system = A(foo, loc=bar) || ... ||  A(bar, true) || ...
```

So, agent `foo` already knows `bar`'s name in the initial state.